### PR TITLE
IME変換確定時もmeeseageがPOSTされてしまう問題とtextareaがclearされない問題を修正

### DIFF
--- a/src/components/section/post.tsx
+++ b/src/components/section/post.tsx
@@ -9,6 +9,16 @@ const Post = () => {
 
   const { post, uploadImage } = usePost();
 
+  const postMesseage = (keyEvent: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const submitButton = document.getElementById("submit")
+      ? document.getElementById("submit")
+      : null;
+    if (submitButton && message && keyEvent.key === "Enter") {
+      submitButton.click();
+      setMessage("");
+    }
+  };
+
   return React.useMemo(() => {
     return (
       <>
@@ -50,11 +60,7 @@ const Post = () => {
               value={message}
               rows={3}
               onChange={(e) => setMessage(e.target.value)}
-              onKeyPress={(e) =>
-                e.key === "Enter"
-                  ? (document.getElementById("submit") as HTMLElement).click()
-                  : ""
-              }></textarea>
+              onKeyPress={(e) => postMesseage(e)}></textarea>
 
             <div className="text-center">
               <input

--- a/src/components/section/post.tsx
+++ b/src/components/section/post.tsx
@@ -49,13 +49,12 @@ const Post = () => {
               maxLength={150}
               value={message}
               rows={3}
-              onChange={e => setMessage(e.target.value)}
-              onKeyDown={e =>
-                e.key === 'Enter'
-                  ? (document.getElementById('submit') as HTMLElement).click()
-                  : ''
-              }
-            ></textarea>
+              onChange={(e) => setMessage(e.target.value)}
+              onKeyPress={(e) =>
+                e.key === "Enter"
+                  ? (document.getElementById("submit") as HTMLElement).click()
+                  : ""
+              }></textarea>
 
             <div className="text-center">
               <input


### PR DESCRIPTION
# 注意

テスト環境用意するのがめんどくさくてテストしてないので、baseでテスト後mergeしてください。
prettierが自動でかかって`'`が`""`に修正されてるので、baseでeslintをかけなおしてください。

# 参考文献
[ブラウザでIME確定時のEnterキー入力をハンドリングしない](https://qiita.com/ledsun/items/31e43a97413dd3c8e38e#fn2)